### PR TITLE
[DONT MERGE YET] fix:  misspelling typo

### DIFF
--- a/app/assets/javascripts/i18n/en.js
+++ b/app/assets/javascripts/i18n/en.js
@@ -1030,7 +1030,7 @@ I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/fa.js
+++ b/app/assets/javascripts/i18n/fa.js
@@ -1030,7 +1030,7 @@ I18n.translations["fa"] = I18n.extend((I18n.translations["fa"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/fi.js
+++ b/app/assets/javascripts/i18n/fi.js
@@ -1030,7 +1030,7 @@ I18n.translations["fi"] = I18n.extend((I18n.translations["fi"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/fy.js
+++ b/app/assets/javascripts/i18n/fy.js
@@ -1030,7 +1030,7 @@ I18n.translations["fy"] = I18n.extend((I18n.translations["fy"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/hi.js
+++ b/app/assets/javascripts/i18n/hi.js
@@ -1030,7 +1030,7 @@ I18n.translations["hi"] = I18n.extend((I18n.translations["hi"] || {}), {
       "link": {
         "back": "वापस, पीछे",
         "large_map": "बड़ा करें",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/is.js
+++ b/app/assets/javascripts/i18n/is.js
@@ -1030,7 +1030,7 @@ I18n.translations["is"] = I18n.extend((I18n.translations["is"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Stækka",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/lt.js
+++ b/app/assets/javascripts/i18n/lt.js
@@ -1031,7 +1031,7 @@ I18n.translations["lt"] = I18n.extend((I18n.translations["lt"] || {}), {
       "link": {
         "back": "atgal",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Išsiųsti paveikslą"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/nn.js
+++ b/app/assets/javascripts/i18n/nn.js
@@ -1030,7 +1030,7 @@ I18n.translations["nn"] = I18n.extend((I18n.translations["nn"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/no.js
+++ b/app/assets/javascripts/i18n/no.js
@@ -1030,7 +1030,7 @@ I18n.translations["no"] = I18n.extend((I18n.translations["no"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/nqo.js
+++ b/app/assets/javascripts/i18n/nqo.js
@@ -1030,7 +1030,7 @@ I18n.translations["nqo"] = I18n.extend((I18n.translations["nqo"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/ro.js
+++ b/app/assets/javascripts/i18n/ro.js
@@ -1031,7 +1031,7 @@ I18n.translations["ro"] = I18n.extend((I18n.translations["ro"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/ro_RO.js
+++ b/app/assets/javascripts/i18n/ro_RO.js
@@ -1030,7 +1030,7 @@ I18n.translations["ro_RO"] = I18n.extend((I18n.translations["ro_RO"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/tlh.js
+++ b/app/assets/javascripts/i18n/tlh.js
@@ -1031,7 +1031,7 @@ I18n.translations["tlh"] = I18n.extend((I18n.translations["tlh"] || {}), {
         "back": "back",
         "edit_node": "Daq choH",
         "large_map": "tInmoH",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "report_bug": "Report a problem",
         "upload": "Upload image"
       },

--- a/app/assets/javascripts/i18n/vi.js
+++ b/app/assets/javascripts/i18n/vi.js
@@ -1030,7 +1030,7 @@ I18n.translations["vi"] = I18n.extend((I18n.translations["vi"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/app/assets/javascripts/i18n/vi_VN.js
+++ b/app/assets/javascripts/i18n/vi_VN.js
@@ -1030,7 +1030,7 @@ I18n.translations["vi_VN"] = I18n.extend((I18n.translations["vi_VN"] || {}), {
       "link": {
         "back": "back",
         "large_map": "Enlarge",
-        "listing": "All places of typ '%{type}' in %{city}",
+        "listing": "All places of type '%{type}' in %{city}",
         "upload": "Upload image"
       },
       "more_data_from": "There is more information about this place, validated by:",

--- a/config/locales/en/wheelmap.yml
+++ b/config/locales/en/wheelmap.yml
@@ -224,7 +224,7 @@ en:
       link:
         back: back
         large_map: Enlarge
-        listing: "All places of typ '%{type}' in %{city}"
+        listing: "All places of type '%{type}' in %{city}"
         upload: "Upload image"
       more_data_from: "There is more information about this place, validated by:"
       show-in-osm: OpenStreetMap


### PR DESCRIPTION
- recompiles i18n-js generated files

**note**: 

@Hoverbear couldn't get the link on local machine, is it because locally we are missing the region, and therefore we don't have that feature activated? Therefore I couldn't test this fix works ...

![screen shot 2017-05-12 at 10 33 43](https://cloud.githubusercontent.com/assets/1539793/25990129/ee577670-36fe-11e7-86ef-7ca0c4ddde61.png)

closes #598 